### PR TITLE
v0.0.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,11 +32,11 @@
         }
 
         static all(iterable) {
-            return new ExtendedPromise(super.all(iterable));
+            return new this(super.all(iterable));
         }
 
         static race(iterable) {
-            return new ExtendedPromise(super.race(iterable));
+            return new this(super.race(iterable));
         }
 
         mkchange(...fn) {

--- a/index.js
+++ b/index.js
@@ -15,6 +15,30 @@
 
     class ExtendedPromise extends Promise {
 
+        constructor(executor) {
+            switch (typeof executor) {
+                case 'function':
+                    super(executor);
+                    return;
+                case 'object':
+                    if (executor instanceof Promise) {
+                        let alexec = (...decide) =>
+                            executor.then(...decide.map(_igretf));
+                        super(alexec);
+                        return;
+                    }
+            }
+            throw new TypeError(`${executor} is not a valid executor`);
+        }
+
+        static all(iterable) {
+            return new ExtendedPromise(super.all(iterable));
+        }
+
+        static race(iterable) {
+            return new ExtendedPromise(super.race(iterable));
+        }
+
         mkchange(...fn) {
             return this.then(...fn);
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 {
 	"name": "extended-promise",
 	"description": "Extend ECMAScript 6 promise",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"author": "Hoàng Văn Khải <hvksmr1996@gmail.com>",
 	"contributors": [
 		"Hoàng Văn Khải <hvksmr1996@gmail.com>"


### PR DESCRIPTION
- Custom constructor which allows `executor` as either a `promise` or a `function`
- Custom methods `::all` and `::race` which create `ExtendedPromise` instead of `Promise`
