### PR TITLE
v0.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.log
+quick-test/*
+!quick-test/*.md
+temp
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+*.log
+quick-test
+test
+temp
+node_modules
+.gitignore
+test.sh
+clean.sh

--- a/index.js
+++ b/index.js
@@ -43,6 +43,14 @@
             return fnlist.reduce((lasted, fn) => lasted.createListenerPromise(fn), new this(promise));
         }
 
+        static resolve(value) {
+            return new this((resolve) => resolve(value));
+        }
+
+        static reject(value) {
+            return new this((_, reject) => reject(value));
+        }
+
         mkchange(...fn) {
             return this.then(...fn);
         }

--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@
             return new this(super.race(iterable));
         }
 
+        static queue(promise, ...fnlist) {
+            return fnlist.reduce((lasted, fn) => lasted.createListenerPromise(fn), new this(promise));
+        }
+
         mkchange(...fn) {
             return this.then(...fn);
         }
@@ -53,6 +57,14 @@
 
         onfinish(onfulfill, onreject) {
             return this.then(_igretf(_getfunc(onfulfill, DONOTHING)), _igretf(_getfunc(onreject, THROW)));
+        }
+
+        createListenerPromise(fn) {
+            return new this.constructor((resolve, reject) => this.onfinish((value) => fn(value, resolve, reject), reject));
+        }
+
+        listener(fn) {
+            return this.createListenerPromise(fn);
         }
 
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 {
 	"name": "extended-promise",
 	"description": "Extend ECMAScript 6 promise",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"author": "Hoàng Văn Khải <hvksmr1996@gmail.com>",
 	"contributors": [
 		"Hoàng Văn Khải <hvksmr1996@gmail.com>"


### PR DESCRIPTION
Added methods:
- `createListenerPromise()` a.k.a `listener()`
- `static queue()`
- Own `static resolve()` and `static reject()` that create instances of `ExtendPromise` instead of native `Promise`
